### PR TITLE
Extra semicolons generated

### DIFF
--- a/lib/fake_function_framework.rb
+++ b/lib/fake_function_framework.rb
@@ -25,7 +25,7 @@ class FakeFunctionFramework < Plugin
       f.puts
       f.puts "//=======Defintions of FFF variables====="
       f.puts %{#include "fff.h"}
-      f.puts "DEFINE_FFF_GLOBALS;"
+      f.puts "DEFINE_FFF_GLOBALS"
     end
   end
 

--- a/lib/fff_mock_generator.rb
+++ b/lib/fff_mock_generator.rb
@@ -156,7 +156,7 @@ class FffMockGenerator
       end
 
       # Close the declaration.
-      output.puts ");"
+      output.puts ")"
     end
   end
 


### PR DESCRIPTION
Hi,

when compiling with GCC & the flag -pedantic,
"warning: extra ';' [-Wpedantic]" pop up.
This path should fix them.