### PR TITLE
Remove semicolon after the macro

### DIFF
--- a/lib/fake_function_framework.rb
+++ b/lib/fake_function_framework.rb
@@ -26,7 +26,7 @@ class FakeFunctionFramework < Plugin
       f.puts
       f.puts "//=======Defintions of FFF variables====="
       f.puts %{#include "fff.h"}
-      f.puts "DEFINE_FFF_GLOBALS;"
+      f.puts "DEFINE_FFF_GLOBALS"
     end
   end
 


### PR DESCRIPTION
It leads to `ISO C does not allow extra ';' outside of a function` compiler warning in pedantic mode.